### PR TITLE
Fix: WindowsGSM Started

### DIFF
--- a/Satisfactory.cs/Satisfactory.cs
+++ b/Satisfactory.cs/Satisfactory.cs
@@ -17,7 +17,7 @@ namespace WindowsGSM.Plugins
         public Plugin Plugin = new Plugin
         {
             name = "WindowsGSM.Satisfactory", // WindowsGSM.XXXX
-            author = "werewolf2150",
+            author = "werewolf2150 and caindrac",
             description = "WindowsGSM plugin for supporting Satisfactory Dedicated Server Early Access",
             version = "1.4",
             url = "https://github.com/werewolf2150/WindowsGSM.Satisfactory", // Github repository link (Best practice)

--- a/Satisfactory.cs/Satisfactory.cs
+++ b/Satisfactory.cs/Satisfactory.cs
@@ -35,7 +35,7 @@ namespace WindowsGSM.Plugins
 
 
         // - Game server Fixed variables
-        public override string StartPath => @"FactoryServer.exe"; // Game server start path
+        public override string StartPath => @"Engine\Binaries\Win64\UnrealServer-Win64-Shipping.exe"; // Game server start path
         public string FullName = "Satisfactory Dedicated Server"; // Game server FullName
         public bool AllowsEmbedConsole = true;  // Does this server support output redirect?
         public int PortIncrements = 1; // This tells WindowsGSM how many ports should skip after installation


### PR DESCRIPTION
WindowsGSM does not correctly go to the started status if you use FactoryServer.exe